### PR TITLE
Fix when $event->getController() is not an array

### DIFF
--- a/EventListener/BreadcrumbListener.php
+++ b/EventListener/BreadcrumbListener.php
@@ -34,6 +34,9 @@ class BreadcrumbListener
      */
     public function onKernelController(FilterControllerEvent $event)
     {
+        if(!is_array($event->getController())) {
+            return;
+        }
         list($controller, $action) = $event->getController();
 
         $class = new \ReflectionClass($controller);

--- a/EventListener/BreadcrumbListener.php
+++ b/EventListener/BreadcrumbListener.php
@@ -34,6 +34,7 @@ class BreadcrumbListener
      */
     public function onKernelController(FilterControllerEvent $event)
     {
+        // Verification for non-array getController() such as ADR pattern: https://github.com/pmjones/adr
         if(!is_array($event->getController())) {
             return;
         }


### PR DESCRIPTION
Hello,

I use this Bundle and I recently update my project to SF 3.4
In my project, I have Sonata Admin and the recently change their pattern.

For example in Sonata Admin 3.37, Dashboard actions is not a controller, it's only an action (pattern change). So this fix the 500 error.

Thank for merging and release this through packagist!